### PR TITLE
Restore and fix rule for computing true covarying sites.

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -602,6 +602,24 @@ rule covarying_sites:
   run:
     covarying_sites_io(input[0], output.json, output.fasta)
 
+rule true_covarying_sites:
+  input:
+    rules.true_sequences.output.fasta
+  output:
+    "output/truth/{dataset}/{reference}_covarying_sites.json"
+  run:
+    covarying_sites(input[0], output[0])
+
+rule covarying_truth_comparison:
+  input:
+    computed=rules.covarying_sites.output.json,
+    reference=rules.situate_references.output[0],
+    truth=rules.true_covarying_sites.output[0]
+  output:
+    "output/{dataset}/{qc}/{read_mapper}/{reference}/acme/covarying_truth.json"
+  run:
+    covarying_truth(input.computed, input.reference, output[0])
+
 rule superreads:
   input:
     alignment=rules.sort_and_index.output.bam,

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,30 @@
 name: haplotype-reconstruction3
 channels:
   - stephenshank
+  - davebx
   - conda-forge
   - bioconda
   - defaults
 dependencies:
-  - snakemake=5.10.0
-  - pysam=0.15.4
-  - numpy=1.18.1
-  - biopython=1.74
-  - pandas=0.25.3
-  - scikit-learn=0.22.1
-  - matplotlib=3.1.2
-  - convex-qsr=0.2.0
-  - scipy=1.4.1
+  - snakemake
+  - pysam
+  - numpy
+  - biopython
+  - pandas
+  - scikit-learn
+  - matplotlib
+  - convex-qsr
+  - scipy
+  - seaborn>=0.9
+  - art
+  - fastp
+  - bowtie2
+  - samtools
+  - emboss
+  - r-tidyverse
+  - mafft
+  - r-regresshaplo
+  - r-seqinr
+  - r-jsonlite
+  - bioconductor-rsamtools
+  - bioconductor-genomicalignments

--- a/py/utils.py
+++ b/py/utils.py
@@ -191,13 +191,19 @@ def extract_truth(
         json.dump(pairwise_distances, json_file, indent=2)
 
 def covarying_truth(
-        input_computed, input_actual, input_reference, output_json
+        input_computed, input_reference, output_json
         ):
+    dataset = input_computed.split('/')[1]
+    if dataset != 'FiveVirusMixIllumina_1':
+        dataset = dataset.split('_')[0]
+    reference_name = input_reference.split('/')[-1].split('.')[0]
+    actual = "output/truth/%s/%s_covarying_sites.json" % (dataset, reference_name)
+
     reference = SeqIO.read(input_reference, 'fasta')
     rl = len(reference.seq)
     with open(input_computed) as input_file:
         cvs = json.load(input_file)
-    with open(input_actual) as input_file:
+    with open(actual) as input_file:
         true_cvs = json.load(input_file)
 
     tp = []

--- a/py/utils.py
+++ b/py/utils.py
@@ -191,19 +191,13 @@ def extract_truth(
         json.dump(pairwise_distances, json_file, indent=2)
 
 def covarying_truth(
-        input_computed, input_reference, output_json
+        input_computed, input_truth, input_reference, output_json
         ):
-    dataset = input_computed.split('/')[1]
-    if dataset != 'FiveVirusMixIllumina_1':
-        dataset = dataset.split('_')[0]
-    reference_name = input_reference.split('/')[-1].split('.')[0]
-    actual = "output/truth/%s/%s_covarying_sites.json" % (dataset, reference_name)
-
     reference = SeqIO.read(input_reference, 'fasta')
     rl = len(reference.seq)
     with open(input_computed) as input_file:
         cvs = json.load(input_file)
-    with open(actual) as input_file:
+    with open(input_truth) as input_file:
         true_cvs = json.load(input_file)
 
     tp = []


### PR DESCRIPTION
This rule will compute true covarying sites in situations where the truth is known (simulations, five virus mixture).

Please confirm that you can make the targets:

```
output/sim-divergedPair_ar-10_seed-1/fastp/bowtie2/pol/acme/covarying_truth.json
output/FiveVirusMixIllumina_1/fastp/bowtie2/pol/acme/covarying_truth.json
```